### PR TITLE
Update ghostagent linux role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible role to install ghostserver
 ===================================
 
-This role installs a [ghosts agent on Linux](https://github.com/cmu-sei/GHOSTS)
+This role installs a [ghosts agent on Linux](https://github.com/cmu-sei/GHOSTS) and optionally starts it as a service on boot.
 
 Requirements
 ------------
@@ -40,6 +40,7 @@ Example Playbook
     - role: atb-ansible-ghostagent
       vars:
         ghostsserver_url: "http://192.168.100.184:5000/api"
+        ghostagent_autostart: false
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Role Variables
 ghostagent_packages:
  - dotnet-sdk-8.0
 
+ghostagent_autostart: true  # Set this to false if you don't want to start ghosts as a service automatically
 ghostsagent_user: "aecid"
-ghostagent_path: "/home/{{ ghostsagent_user }}/"
+ghostagent_path: "/home/{{ ghostsagent_user }}/ghosts-client-linux-v8.0.0"
 ghostagent_timeline_file: "timeline.json.j2"
 
 ghostsserver_url: "http://192.168.100.184:5000/api"
@@ -41,6 +42,18 @@ Example Playbook
       vars:
         ghostsserver_url: "http://192.168.100.184:5000/api"
         ghostagent_autostart: false
+```
+
+As the ghostagent is registered as a systemd service, you can use the 
+following commands for manual inspection:
+
+```shell
+systemctl enable ghostagent
+systemctl disable ghostagent
+systemctl start ghostagent
+systemctl stop ghostagent 
+systemctl restart ghostagent
+systemctl status ghostagent
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ ghostagent_packages:
 
 ghostagent_autostart: true  # Set this to false if you don't want to start ghosts as a service automatically
 ghostsagent_user: "aecid"
-ghostagent_path: "/home/{{ ghostsagent_user }}/"
+ghostagent_path: "/home/{{ ghostsagent_user }}/ghosts-client-linux-v8.0.0"
 ghostagent_timeline_file: "timeline.json.j2"
 
 ghostsserver_url: "http://192.168.100.184:5000/api"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 ghostagent_packages:
  - dotnet-sdk-8.0
 
+ghostagent_autostart: true  # Set this to false if you don't want to start ghosts as a service automatically
 ghostsagent_user: "aecid"
 ghostagent_path: "/home/{{ ghostsagent_user }}/"
 ghostagent_timeline_file: "timeline.json.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,3 +99,23 @@
   tags:
     - install
     - chrome
+
+- name: Deploy ghostagent systemd service
+  become: true
+  ansible.builtin.template:
+    src: ghosts.j2
+    dest: /etc/systemd/system/ghostagent.service
+  tags:
+    - start
+    - ghostagent
+
+- name: Enable and start ghostagent service
+  become: true
+  ansible.builtin.service:
+    name: ghostagent
+    enabled: "{{ ghostagent_autostart }}"
+    state: "{{ 'started' if ghostagent_autostart else 'stopped' }}"
+  when: ghostagent_autostart
+  tags:
+    - start
+    - ghostagent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,19 +56,13 @@
     - update
     - ghostagent
 
-- name: Download google-chrome-stable
+# Download chrome and chromedriver binaries from: https://googlechromelabs.github.io/chrome-for-testing/
+- name: Download google-chrome-stable binary
   become: true
-  ansible.builtin.get_url:
-    url: "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
-    dest: "/opt/google-chrome-stable_current_amd64.deb"
-  tags:
-    - install
-    - chrome
-
-- name: Install google-chrome-stable
-  become: true
-  ansible.builtin.apt:
-    deb: "/opt/google-chrome-stable_current_amd64.deb"
+  ansible.builtin.unarchive:
+    src: "https://storage.googleapis.com/chrome-for-testing-public/129.0.6668.58/linux64/chrome-linux64.zip"
+    dest: "{{ ghostagent_path }}/"
+    remote_src: yes
   tags:
     - install
     - chrome
@@ -76,7 +70,7 @@
 - name: Get Chrome version
   become: true
   ansible.builtin.shell:
-    cmd: "google-chrome --version | grep -oP '[0-9]+.[0-9]+.[0-9]+.[0-9]+'"
+    cmd: "{{ ghostagent_path }}/chrome-linux64/chrome --version | grep -oP '[0-9]+.[0-9]+.[0-9]+.[0-9]+'"
   register: chrome_version
   tags:
     - install
@@ -92,10 +86,10 @@
     - install
     - chrome
 
-- name: Move ChromeDriver to /usr/local/bin and make it executable
+- name: Move ChromeDriver to ghosts folder and make it executable
   become: true
   ansible.builtin.shell:
-    cmd: "mv /opt/chromedriver-linux64/chromedriver /usr/local/bin/ && chmod 0755 /usr/local/bin/chromedriver"
+    cmd: "mv /opt/chromedriver-linux64/chromedriver {{ ghostagent_path }}/ && chmod 0755 {{ ghostagent_path }}/chromedriver"
   tags:
     - install
     - chrome

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   become_user: "{{ ghostsagent_user }}"
   ansible.builtin.unarchive:
     src: "https://cmu.box.com/shared/static/tdozbmmdyvajubohwtnon1huyfqjuwrz.zip"
-    dest: "{{ ghostagent_path }}"
+    dest: "/home/{{ ghostsagent_user }}/"
     remote_src: yes
   tags:
     - install
@@ -41,7 +41,7 @@
   become_user: "{{ ghostsagent_user }}"
   ansible.builtin.template:
     src: application.json.j2
-    dest: "{{ ghostagent_path }}/ghosts-client-linux-v8.0.0/config/application.json"
+    dest: "{{ ghostagent_path }}/config/application.json"
   tags:
     - install
     - ghostagent
@@ -51,7 +51,7 @@
   become_user: "{{ ghostsagent_user }}"
   ansible.builtin.template:
     src: "{{ ghostagent_timeline_file }}"
-    dest: "{{ ghostagent_path }}/ghosts-client-linux-v8.0.0/config/timeline.json"
+    dest: "{{ ghostagent_path }}/config/timeline.json"
   tags:
     - update
     - ghostagent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,18 +60,9 @@
 - name: Download google-chrome-stable binary
   become: true
   ansible.builtin.unarchive:
-    src: "https://storage.googleapis.com/chrome-for-testing-public/129.0.6668.58/linux64/chrome-linux64.zip"
+    src: "https://storage.googleapis.com/chrome-for-testing-public/125.0.6422.60/linux64/chrome-linux64.zip"
     dest: "{{ ghostagent_path }}/"
     remote_src: yes
-  tags:
-    - install
-    - chrome
-
-- name: Get Chrome version
-  become: true
-  ansible.builtin.shell:
-    cmd: "{{ ghostagent_path }}/chrome-linux64/chrome --version | grep -oP '[0-9]+.[0-9]+.[0-9]+.[0-9]+'"
-  register: chrome_version
   tags:
     - install
     - chrome
@@ -79,7 +70,7 @@
 - name: Download and unarchive ChromeDriver
   become: true
   ansible.builtin.unarchive:
-    src: "https://storage.googleapis.com/chrome-for-testing-public/{{ chrome_version.stdout }}/linux64/chromedriver-linux64.zip"
+    src: "https://storage.googleapis.com/chrome-for-testing-public/125.0.6422.60/linux64/chromedriver-linux64.zip"
     dest: /opt/
     remote_src: yes
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,35 +56,6 @@
     - update
     - ghostagent
 
-# Download chrome and chromedriver binaries from: https://googlechromelabs.github.io/chrome-for-testing/
-- name: Download google-chrome-stable binary
-  become: true
-  ansible.builtin.unarchive:
-    src: "https://storage.googleapis.com/chrome-for-testing-public/125.0.6422.60/linux64/chrome-linux64.zip"
-    dest: "{{ ghostagent_path }}/"
-    remote_src: yes
-  tags:
-    - install
-    - chrome
-
-- name: Download and unarchive ChromeDriver
-  become: true
-  ansible.builtin.unarchive:
-    src: "https://storage.googleapis.com/chrome-for-testing-public/125.0.6422.60/linux64/chromedriver-linux64.zip"
-    dest: /opt/
-    remote_src: yes
-  tags:
-    - install
-    - chrome
-
-- name: Move ChromeDriver to ghosts folder and make it executable
-  become: true
-  ansible.builtin.shell:
-    cmd: "mv /opt/chromedriver-linux64/chromedriver {{ ghostagent_path }}/ && chmod 0755 {{ ghostagent_path }}/chromedriver"
-  tags:
-    - install
-    - chrome
-
 - name: Deploy ghostagent systemd service
   become: true
   ansible.builtin.template:

--- a/templates/ghosts.j2
+++ b/templates/ghosts.j2
@@ -3,10 +3,10 @@ Description=Start ghostagent at startup
 After=multi-user.target
 
 [Service]
-WorkingDirectory={{ ghostagent_path }}/ghosts-client-linux-v8.0.0
+WorkingDirectory={{ ghostagent_path }}
 User={{ ghostsagent_user }}
 Type=simple
-ExecStart={{ ghostagent_path }}/ghosts-client-linux-v8.0.0/ghost.agent.linux
+ExecStart={{ ghostagent_path }}/ghosts.client.linux
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/ghosts.j2
+++ b/templates/ghosts.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Start ghostagent at startup
+After=multi-user.target
+
+[Service]
+WorkingDirectory={{ ghostagent_path }}/ghosts-client-linux-v8.0.0
+User={{ ghostsagent_user }}
+Type=simple
+ExecStart={{ ghostagent_path }}/ghosts-client-linux-v8.0.0/ghost.agent.linux
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/timeline.json.j2
+++ b/templates/timeline.json.j2
@@ -10,10 +10,10 @@
             "HandlerArgs": {
                 "executable-location": "{{ ghostagent_path }}/chrome-linux64/",
                 "isheadless": "true",
-                "blockimages": "true",
-                "blockstyles": "true",
+                "blockimages": "false",
+                "blockstyles": "false",
                 "blockflash": "true",
-                "blockscripts": "true",
+                "blockscripts": "false",
                 "stickiness": 0,
                 "stickiness-depth-min": 3,
                 "stickiness-depth-max": 10,
@@ -217,6 +217,30 @@
                         "Base": 50000,
                         "Range": 1000
                     },
+                    "DelayBefore": 0
+                },
+                {
+                    "Command": "click.by.cssselector",
+                    "CommandArgs": [
+                        "#logoutButton"
+                    ],
+                    "DelayAfter": 3000,
+                    "DelayBefore": 3000
+                },
+                {
+                    "Command": "click.by.cssselector",
+                    "CommandArgs": [
+                        "button[name='action'][value='logout']"
+                    ],
+                    "DelayAfter": 3000,
+                    "DelayBefore": 3000
+                },
+                {
+                    "Command": "execute.script",
+                    "CommandArgs": [
+                        "window.localStorage.clear(); document.cookie.split(';').forEach(function(c) { document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/'; });"
+                    ],
+                    "DelayAfter": 1000,
                     "DelayBefore": 0
                 }
             ],

--- a/templates/timeline.json.j2
+++ b/templates/timeline.json.j2
@@ -8,7 +8,7 @@
             "UtcTimeOn": "00:00:00",
             "UtcTimeOff": "24:00:00",
             "HandlerArgs": {
-                "executable-location": "/usr/bin/google-chrome",
+                "executable-location": "{{ ghostagent_path }}/chrome-linux64/",
                 "isheadless": "true",
                 "blockimages": "true",
                 "blockstyles": "true",

--- a/templates/timeline.json.j2
+++ b/templates/timeline.json.j2
@@ -3,12 +3,11 @@
     "status": "Run",
     "TimeLineHandlers": [
         {
-            "HandlerType": "BrowserChrome",
+            "HandlerType": "BrowserFirefox",
             "Initial": "about:config",
             "UtcTimeOn": "00:00:00",
             "UtcTimeOff": "24:00:00",
             "HandlerArgs": {
-                "executable-location": "{{ ghostagent_path }}/chrome-linux64/",
                 "isheadless": "true",
                 "blockimages": "false",
                 "blockstyles": "false",
@@ -247,12 +246,11 @@
             "SchedulerType": "Other"
         },
         {
-            "HandlerType": "BrowserChrome",
+            "HandlerType": "BrowserFirefox",
             "Initial": "about:config",
             "UtcTimeOn": "00:00:00",
             "UtcTimeOff": "24:00:00",
             "HandlerArgs": {
-                "executable-location": "/usr/bin/google-chrome",
                 "isheadless": "false",
                 "blockimages": "true",
                 "blockstyles": "true",


### PR DESCRIPTION
There are two main changes in this PR:
- Ghostagent is now configured to run as a systemd service. There is a `ghostagent_autostart` variable with the default value `true`. This can be set to `false`, if we don't want the service to start on boot.
- Removed manual browser installation steps, as Selenium actually handles this automatically, and it overwrites the `"executable-location"` setting provided by ghosts (ref: [Selenium 4.11.0 update](https://www.selenium.dev/blog/2023/whats-new-in-selenium-manager-with-selenium-4.11.0/)).
