### PR TITLE
ensure config dir exiists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,12 @@
     - install
     - ghostagent
 
+- name: Ensure config dir exists
+  ansible.builtin.file:
+    path: "{{ ghostagent_path }}/config"
+    state: directory
+    mode: '0755'
+
 - name: Update application.json with the ghostsserver url
   become: true
   become_user: "{{ ghostsagent_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,8 @@
 - name: Ensure config dir exists
   ansible.builtin.file:
     path: "{{ ghostagent_path }}/config"
+    owner: "{{ ghostsagent_user }}"
+    group: "{{ ghostsagent_user }}"
     state: directory
     mode: '0755'
 


### PR DESCRIPTION
add task to ensure config directory exists before copying files with ansible.builtin.template